### PR TITLE
Update Wikipedia license to 4.0 in footer

### DIFF
--- a/src/routes/Footer.svelte
+++ b/src/routes/Footer.svelte
@@ -3,7 +3,7 @@
         <div>
             Text is available under the
             <a
-                href="https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_4.0_International_License"
+                href="https://en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_4.0_International_License"
             >
                 Creative Commons Attribution-ShareAlike License</a
             >.

--- a/src/routes/Footer.svelte
+++ b/src/routes/Footer.svelte
@@ -3,7 +3,7 @@
         <div>
             Text is available under the
             <a
-                href="https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_4.0_Unported_License"
+                href="https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_4.0_International_License"
             >
                 Creative Commons Attribution-ShareAlike License</a
             >.

--- a/src/routes/Footer.svelte
+++ b/src/routes/Footer.svelte
@@ -3,7 +3,7 @@
         <div>
             Text is available under the
             <a
-                href="https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License"
+                href="https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_4.0_Unported_License"
             >
                 Creative Commons Attribution-ShareAlike License</a
             >.


### PR DESCRIPTION
see https://diff.wikimedia.org/2023/06/29/stepping-into-the-future-wikimedia-projects-transition-to-creative-commons-4-0-license/